### PR TITLE
Disable logging battery stats in dmesg

### DIFF
--- a/external/libhealthd/healthd_board_montblanc.cpp
+++ b/external/libhealthd/healthd_board_montblanc.cpp
@@ -31,5 +31,5 @@ void healthd_board_init(struct healthd_config *config)
 int healthd_board_battery_update(struct android::BatteryProperties *props)
 {
     // return 0 to log periodic polled battery status to kernel log
-    return 0;
+    return 1;
 }


### PR DESCRIPTION
Change-Id: I61a6a070703263377213801fc697e4c335056213
